### PR TITLE
Support split TTL/RS485 sync operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,4 +48,8 @@ install(TARGETS
   DESTINATION lib/${PROJECT_NAME}
 )
 
+install(DIRECTORY config
+  DESTINATION share/${PROJECT_NAME}
+)
+
 ament_package()

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ dynamixel_controller は、Dynamixel アクチュエータとの通信を行う�
 
 ・サンプル Python クライアント
 　- Python ノードからの命令送信例（SYNC_READ）および応答受信例を提供
+・バス設定
+　- `config/bus_config.yaml` で TTL と RS485 に接続されたモータ ID を指定可能
 
 【ビルド方法】
 
@@ -60,6 +62,11 @@ dynamixel_controller ノードは、実行可能ファイル "dynamixel_controll
 下記のコマンドで起動してください：
     ``` bash
      ros2 run dynamixel_controller dynamixel_controller_node
+    ```
+モータがTTL接続かRS485接続かを区別するために、パラメータファイルを使用してIDの割り当てを設定します。サンプルの`config/bus_config.yaml`を編集し、以下のようにノード起動時に読み込みます。
+
+    ``` bash
+    ros2 run dynamixel_controller dynamixel_controller_node --ros-args --params-file config/bus_config.yaml
     ```
 ＜Python クライアントの利用例＞
 下記のサンプルは、Python ノードから C++ ノードに対して命令を送信する例です。

--- a/config/bus_config.yaml
+++ b/config/bus_config.yaml
@@ -1,0 +1,4 @@
+dynamixel_controller_node:
+  ros__parameters:
+    ttl_ids: [1]
+    rs485_ids: [2]

--- a/include/dynamixel_controller/dynamixel_controller.hpp
+++ b/include/dynamixel_controller/dynamixel_controller.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <unordered_set>
 
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/u_int8_multi_array.hpp"
@@ -28,6 +29,10 @@ private:
     // Dynamixel SDK 用オブジェクト
     dynamixel::PortHandler   *port_handler_;
     dynamixel::PacketHandler *packet_handler_;
+
+    // Bus configuration
+    std::unordered_set<uint8_t> ttl_ids_;
+    std::unordered_set<uint8_t> rs485_ids_;
 
     // デバイスパラメータ（例：モータID、プロトコルバージョン）
     const int dxl_id_ = 1;


### PR DESCRIPTION
## Summary
- add parameters for TTL and RS485 bus IDs
- separate SYNC_READ and SYNC_WRITE into TTL and RS485 operations
- install example `config/bus_config.yaml`
- document how to use the config in README

## Testing
- `colcon build --packages-select dynamixel_controller` *(fails: command not found)*
- `cmake ..` in build directory *(fails: missing ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68576f85501c8323b15e384fd31e1056